### PR TITLE
Fix hasbang

### DIFF
--- a/ytsurf.sh
+++ b/ytsurf.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 # -- CONFIGURATION --


### PR DESCRIPTION
Fixes: #7 

On mac /bin/bash can point to older version of bash that doesn't have mapfile yet even if there is a newer bash available on the $PATH

/usr/bin/env bash will point to bash interpreter from the $PATH