### PR TITLE
chore: Fix broken checksum for 3.1.2

### DIFF
--- a/ytsurf.rb
+++ b/ytsurf.rb
@@ -2,7 +2,7 @@ class Ytsurf < Formula
   desc "YouTube in your terminal. Clean and distraction-free"
   homepage ""
   url "https://github.com/Stan-breaks/ytsurf/archive/refs/tags/v3.1.2.zip"
-  sha256 "7dfa675fa4b0479587b1c9dee11165f7739387a68fc2a9b7a4e854c963bd4ff1"
+  sha256 "dab187f9e42327d2dacc81bfb6a10cfc526687feb85162b8554d3d05f4ad1f69"
   version "3.1.2"
   license "GPL-3.0"
   


### PR DESCRIPTION
**IMPORTANT**: Do *not* make a new release after the formula checksum is updated, as that will be a whole new version number with a new checksum, thus breaking the formula again