### PR TITLE
Fix broken Checksum issues when installing from Brew

### DIFF
--- a/ytsurf.rb
+++ b/ytsurf.rb
@@ -2,7 +2,7 @@ class Ytsurf < Formula
   desc "YouTube in your terminal. Clean and distraction-free"
   homepage ""
   url "https://github.com/Stan-breaks/ytsurf/archive/refs/tags/v3.1.3.zip"
-  sha256 "ab7f508b073bdf3c6507522e6c2a497b4b626cbb5742ceb8bee661263462543e"
+  sha256 "02cc44ca271d9ba73cc9b3995f65471b80b3e44a8a7b2f6ab15145ac65ce0f5b"
   version "3.1.3"
   license "GPL-3.0"
   


### PR DESCRIPTION
I was trying to install from homebrew on MacOS. I got this error.
```
✘ Formula ytsurf (3.1.3)                                                    Verifying    31.0KB/-------
Error: Formula reports different checksum:  ab7f508b073bdf3c6507522e6c2a497b4b626cbb5742ceb8bee661263462543e
       SHA-256 checksum of downloaded file: 02cc44ca271d9ba73cc9b3995f65471b80b3e44a8a7b2f6ab15145ac65ce0f5b
```

This PR remedies that fix. 

This if my first time attempting to fix a checksum issue, so do let me know whether i've changed the right thing :)