### PR TITLE
Add support for IINA video player

### DIFF
--- a/ytsurf.sh
+++ b/ytsurf.sh
@@ -393,6 +393,7 @@ check_dependencies() {
 
   local required_deps=("yt-dlp" "mpv" "jq" "curl" "perl")
   [ "$player" == "syncplay" ] && required_deps+=("syncplay")
+  [ "$player" == "iina" ] && required_deps+=("iina")
 
   for dep in "${required_deps[@]}"; do
     if ! command -v "$dep" &>/dev/null; then
@@ -880,6 +881,15 @@ play_video() {
     }
     "$player" "$video_url"
     exit 0
+    ;;
+  iina)
+    player="$player --keep-open=no --really-quiet --input-ipc-server=$YTSURF_SOCKET"
+    [ "$audio_only" == "true" ] && player="$player --no-video"
+    [ -n "$format_code" ] && player="$player --ytdl-format=\"$format_code\""
+
+    player="$player $video_url"
+    eval "$player"
+    player="iina"
     ;;
   esac
 }


### PR DESCRIPTION
Hi again!

[IINA](https://iina.io/) is a popular Macos specific player that is widely used in other programs like `ani-cli`. This PR adds support for setting your player to be iina :)

You have to choose `iina` in your config

```sh
default_player="iina"
```

Thanks again for making this shell script ❤️ . It's been really helpfull for keeping me mindfull about my youtube use
