### PR TITLE
fix: correct sha256 checksum for v3.1.6 homebrew formula

### DIFF
--- a/ytsurf.rb
+++ b/ytsurf.rb
@@ -2,7 +2,7 @@ class Ytsurf < Formula
   desc "YouTube in your terminal. Clean and distraction-free"
   homepage ""
   url "https://github.com/Stan-breaks/ytsurf/archive/refs/tags/v3.1.6.zip"
-  sha256 "f7752d8dc4ebdcaa8703f97940cdd2be9f44b077bb4f7ffa28279bfc1bd928ec"
+  sha256 "5425763f2d60cec3c23adc662fdfcf5957e9137923a189d6388e027a6f7b29d8"
   version "3.1.6"
   license "GPL-3.0"
   


### PR DESCRIPTION
## Problem
`brew install stan-breaks/ytsurf/ytsurf` fails with a checksum mismatch:

```
Error: Formula reports different checksum:  f7752d8dc4ebdcaa8703f97940cdd2be9f44b077bb4f7ffa28279bfc1bd928ec
       SHA-256 checksum of downloaded file: 5425763f2d60cec3c23adc662fdfcf5957e9137923a189d6388e027a6f7b29d8
```

## Root Cause
In [`d3deb3b`](https://github.com/Stan-breaks/ytsurf/commit/d3deb3be497624d5f43b3440270b57a31cf11c44), the URL and version were bumped from [`v3.1.5`](https://github.com/Stan-breaks/ytsurf/releases/tag/v3.1.5) to [`v3.1.6`](https://github.com/Stan-breaks/ytsurf/releases/tag/v3.1.6) but the sha256 was left as the [`v3.1.5`](https://github.com/Stan-breaks/ytsurf/releases/tag/v3.1.5) hash.

## Fix
Updated the sha256 to match the actual [`v3.1.6`](https://github.com/Stan-breaks/ytsurf/releases/tag/v3.1.6) archive.